### PR TITLE
Defaults to maintaining existing text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### 2.0.5
+
+No longer defaults to the selected text being replaced by the document/page
+title. If a user selects "Always Show Current Title," the display text will be
+replaced by the doc title, but the original text will be stashed in case they
+uncheck the box.
+
 ### 2.0.4
 
 Support for the `target` attribute. Thanks to Antoine Beauvais-Lacasse.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-rich-text-permalinks",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Enhances ApostropheCMS rich text widgets with smart links, rich inline tooltips, and in-text variable replacement",
   "main": "index.js",
   "scripts": {
@@ -13,14 +13,9 @@
   "keywords": [
     "apostrophecms",
     "apostrophe",
-    "cms",
-    "apostrophe",
-    "cms",
-    "content",
-    "management",
-    "system"
+    "permalinks"
   ],
-  "author": "P'unk Avenue LLC",
+  "author": "Apostrophe Technologies",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/apostrophecms/apostrophe-rich-text-permalinks/issues"

--- a/public/js/ckeditorPlugins/permalink/plugin.js
+++ b/public/js/ckeditorPlugins/permalink/plugin.js
@@ -1,6 +1,7 @@
 CKEDITOR.plugins.add('permalink', {
   init: function(editor) {
     var linkPlugin = CKEDITOR.plugins.link;
+
     var superParseLinkAttributes = linkPlugin.parseLinkAttributes;
     linkPlugin.parseLinkAttributes = function(editor, element) {
       var href = (element && (element.data('cke-saved-href') || element.getAttribute('href'))) || '';
@@ -78,7 +79,7 @@ CKEDITOR.plugins.add('permalink', {
                   return;
                 }
                 el.aposDocId = doc._id;
-                el.getDialog().getContentElement('info', 'linkDisplayText').setValue(doc.title);
+
                 el.getDialog().getContentElement('info', 'docChosen').setValue(doc.title);
               });
             },
@@ -112,9 +113,31 @@ CKEDITOR.plugins.add('permalink', {
             id: 'docUpdateTitle',
             label: 'Always Show Current Title',
             required: false,
-            setup: function(data) {
-              if (data.docUpdateTitle) {
-                this.setValue('checked', 'checked');
+            onClick : function() {
+              var el = this;
+              var docTitle = el.getDialog()
+                .getContentElement('info', 'docChosen').getValue();
+
+              if (!docTitle) {
+                return;
+              }
+
+
+              if(this.getValue()) {
+                // If enabled, replace the `linkDisplayText` with the doc title.
+                var currentText = el.getDialog()
+                .getContentElement('info', 'linkDisplayText').getValue();
+
+                el.getElement().setAttribute('data-permalink-orig-text', currentText);
+
+                el.getDialog().getContentElement('info', 'linkDisplayText')
+                  .setValue(docTitle);
+              } else {
+                // If disabled, return the original text to `linkDisplayText`
+                var origText = el.getElement().getAttribute('data-permalink-orig-text');
+
+                el.getDialog().getContentElement('info', 'linkDisplayText')
+                  .setValue(origText);
               }
             },
             commit: function(data) {


### PR DESCRIPTION
Resolves #4 

This follows the principle of avoiding any surprises should the end user not be hawk-eyed and experienced enough to uncheck the right box. We default to keeping the link text as-is, with the checkbox to override that with the doc title.